### PR TITLE
Fix minor naming issues from person to client

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -72,7 +72,7 @@ The **API** of this component is specified in [`Ui.java`](https://github.com/se-
 
 ![Structure of the UI Component](images/UiClassDiagram.png)
 
-The UI consists of a `MainWindow` that is made up of parts e.g.`CommandBox`, `ResultDisplay`, `PersonListPanel`, `StatusBarFooter` etc. All these, including the `MainWindow`, inherit from the abstract `UiPart` class which captures the commonalities between classes that represent parts of the visible GUI.
+The UI consists of a `MainWindow` that is made up of parts e.g.`CommandBox`, `ResultDisplay`, `ClientListPanel`, `StatusBarFooter` etc. All these, including the `MainWindow`, inherit from the abstract `UiPart` class which captures the commonalities between classes that represent parts of the visible GUI.
 
 The `UI` component uses the JavaFx UI framework. The layout of these UI parts are defined in matching `.fxml` files that are in the `src/main/resources/view` folder. For example, the layout of the [`MainWindow`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/java/seedu/address/ui/MainWindow.java) is specified in [`MainWindow.fxml`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/resources/view/MainWindow.fxml)
 
@@ -81,7 +81,7 @@ The `UI` component,
 * executes user commands using the `Logic` component.
 * listens for changes to `Model` data so that the UI can be updated with the modified data.
 * keeps a reference to the `Logic` component, because the `UI` relies on the `Logic` to execute commands.
-* depends on some classes in the `Model` component, as it displays `Person` object residing in the `Model`.
+* depends on some classes in the `Model` component, as it displays `Client` object residing in the `Model`.
 
 ### Logic component
 
@@ -120,12 +120,12 @@ How the parsing works:
 
 The `Model` component,
 
-* stores the address book data i.e., all `Person` objects (which are contained in a `UniquePersonList` object).
-* stores the currently 'selected' `Person` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Person>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
+* stores the address book data i.e., all `Client` objects (which are contained in a `UniqueClientList` object).
+* stores the currently 'selected' `Client` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Client>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
 * stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
 * does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)
 
-<div markdown="span" class="alert alert-info">:information_source: **Note:** An alternative (arguably, a more OOP) model is given below. It has a `Tag` list in the `AddressBook`, which `Person` references. This allows `AddressBook` to only require one `Tag` object per unique tag, instead of each `Person` needing their own `Tag` objects.<br>
+<div markdown="span" class="alert alert-info">:information_source: **Note:** An alternative (arguably, a more OOP) model is given below. It has a `Tag` list in the `AddressBook`, which `Client` references. This allows `AddressBook` to only require one `Tag` object per unique tag, instead of each `Client` needing their own `Tag` objects.<br>
 
 <img src="images/BetterModelClassDiagram.png" width="450" />
 

--- a/docs/diagrams/ArchitectureSequenceDiagram.puml
+++ b/docs/diagrams/ArchitectureSequenceDiagram.puml
@@ -13,7 +13,7 @@ activate ui UI_COLOR
 ui -[UI_COLOR]> logic : execute("delete 1")
 activate logic LOGIC_COLOR
 
-logic -[LOGIC_COLOR]> model : deletePerson(p)
+logic -[LOGIC_COLOR]> model : deleteClient(p)
 activate model MODEL_COLOR
 
 model -[MODEL_COLOR]-> logic

--- a/docs/diagrams/BetterModelClassDiagram.puml
+++ b/docs/diagrams/BetterModelClassDiagram.puml
@@ -4,18 +4,18 @@ skinparam arrowThickness 1.1
 skinparam arrowColor MODEL_COLOR
 skinparam classBackgroundColor MODEL_COLOR
 
-AddressBook *-right-> "1" UniquePersonList
+AddressBook *-right-> "1" UniqueClientList
 AddressBook *-right-> "1" UniqueTagList
-UniqueTagList -[hidden]down- UniquePersonList
-UniqueTagList -[hidden]down- UniquePersonList
+UniqueTagList -[hidden]down- UniqueClientList
+UniqueTagList -[hidden]down- UniqueClientList
 
 UniqueTagList *-right-> "*" Tag
-UniquePersonList -right-> Person
+UniqueClientList -right-> Client
 
-Person -up-> "*" Tag
+Client -up-> "*" Tag
 
-Person *--> Name
-Person *--> Phone
-Person *--> Email
-Person *--> Address
+Client *--> Name
+Client *--> Phone
+Client *--> Email
+Client *--> Address
 @enduml

--- a/docs/diagrams/DeleteSequenceDiagram.puml
+++ b/docs/diagrams/DeleteSequenceDiagram.puml
@@ -48,7 +48,7 @@ deactivate AddressBookParser
 LogicManager -> DeleteCommand : execute()
 activate DeleteCommand
 
-DeleteCommand -> Model : deletePerson(1)
+DeleteCommand -> Model : deleteClient(1)
 activate Model
 
 Model --> DeleteCommand

--- a/docs/diagrams/ModelClassDiagram.puml
+++ b/docs/diagrams/ModelClassDiagram.puml
@@ -12,8 +12,8 @@ Class AddressBook
 Class ModelManager
 Class UserPrefs
 
-Class UniquePersonList
-Class Person
+Class UniqueClientList
+Class Client
 Class Address
 Class Email
 Class Name
@@ -34,17 +34,17 @@ ModelManager -left-> "1" AddressBook
 ModelManager -right-> "1" UserPrefs
 UserPrefs .up.|> ReadOnlyUserPrefs
 
-AddressBook *--> "1" UniquePersonList
-UniquePersonList --> "~* all" Person
-Person *--> Name
-Person *--> Phone
-Person *--> Email
-Person *--> Address
-Person *--> "*" Tag
+AddressBook *--> "1" UniqueClientList
+UniqueClientList --> "~* all" Client
+Client *--> Name
+Client *--> Phone
+Client *--> Email
+Client *--> Address
+Client *--> "*" Tag
 
 Name -[hidden]right-> Phone
 Phone -[hidden]right-> Address
 Address -[hidden]right-> Email
 
-ModelManager -->"~* filtered" Person
+ModelManager -->"~* filtered" Client
 @enduml

--- a/docs/diagrams/StorageClassDiagram.puml
+++ b/docs/diagrams/StorageClassDiagram.puml
@@ -18,7 +18,7 @@ package "AddressBook Storage" #F4F6F6{
 Class "<<interface>>\nAddressBookStorage" as AddressBookStorage
 Class JsonAddressBookStorage
 Class JsonSerializableAddressBook
-Class JsonAdaptedPerson
+Class JsonAdaptedClient
 Class JsonAdaptedTag
 }
 
@@ -37,7 +37,7 @@ Storage -right-|> AddressBookStorage
 JsonUserPrefsStorage .up.|> UserPrefsStorage
 JsonAddressBookStorage .up.|> AddressBookStorage
 JsonAddressBookStorage ..> JsonSerializableAddressBook
-JsonSerializableAddressBook --> "*" JsonAdaptedPerson
-JsonAdaptedPerson --> "*" JsonAdaptedTag
+JsonSerializableAddressBook --> "*" JsonAdaptedClient
+JsonAdaptedClient --> "*" JsonAdaptedTag
 
 @enduml

--- a/docs/diagrams/UiClassDiagram.puml
+++ b/docs/diagrams/UiClassDiagram.puml
@@ -11,8 +11,8 @@ Class UiManager
 Class MainWindow
 Class HelpWindow
 Class ResultDisplay
-Class PersonListPanel
-Class PersonCard
+Class ClientListPanel
+Class ClientCard
 Class StatusBarFooter
 Class CommandBox
 }
@@ -32,26 +32,26 @@ UiManager .left.|> Ui
 UiManager -down-> "1" MainWindow
 MainWindow *-down->  "1" CommandBox
 MainWindow *-down-> "1" ResultDisplay
-MainWindow *-down-> "1" PersonListPanel
+MainWindow *-down-> "1" ClientListPanel
 MainWindow *-down-> "1" StatusBarFooter
 MainWindow --> "0..1" HelpWindow
 
-PersonListPanel -down-> "*" PersonCard
+ClientListPanel -down-> "*" ClientCard
 
 MainWindow -left-|> UiPart
 
 ResultDisplay --|> UiPart
 CommandBox --|> UiPart
-PersonListPanel --|> UiPart
-PersonCard --|> UiPart
+ClientListPanel --|> UiPart
+ClientCard --|> UiPart
 StatusBarFooter --|> UiPart
 HelpWindow --|> UiPart
 
-PersonCard ..> Model
+ClientCard ..> Model
 UiManager -right-> Logic
 MainWindow -left-> Logic
 
-PersonListPanel -[hidden]left- HelpWindow
+ClientListPanel -[hidden]left- HelpWindow
 HelpWindow -[hidden]left- CommandBox
 CommandBox -[hidden]left- ResultDisplay
 ResultDisplay -[hidden]left- StatusBarFooter

--- a/docs/diagrams/tracing/LogicSequenceDiagram.puml
+++ b/docs/diagrams/tracing/LogicSequenceDiagram.puml
@@ -13,7 +13,7 @@ create ecp
 abp -> ecp
 abp -> ecp ++: parse(arguments)
 create ec
-ecp -> ec ++: index, editPersonDescriptor
+ecp -> ec ++: index, editClientDescriptor
 ec --> ecp --
 ecp --> abp --: command
 abp --> logic --: command

--- a/docs/tutorials/AddRemark.md
+++ b/docs/tutorials/AddRemark.md
@@ -225,7 +225,11 @@ If you are stuck, check out the sample
 
 ## Add `Remark` to the model
 
+<<<<<<< HEAD
 Now that we have all the information that we need, let’s lay the groundwork for propagating the remarks added into the in-memory storage of client data. We achieve that by working with the `Person` model. Each field in a Person is implemented as a separate class (e.g. a `Name` object represents the client’s name). That means we should add a `Remark` class so that we can use a `Remark` object to represent a remark given to a client.
+=======
+Now that we have all the information that we need, let’s lay the groundwork for propagating the remarks added into the in-memory storage of client data. We achieve that by working with the `Client` model. Each field in a Client is implemented as a separate class (e.g. a `Name` object represents the client’s name). That means we should add a `Remark` class so that we can use a `Remark` object to represent a remark given to a client.
+>>>>>>> branch-person-to-client
 
 ### Add a new `Remark` class
 
@@ -244,7 +248,7 @@ Without getting too deep into `fxml`, let’s go on a 5 minute adventure to get 
 
 Simply add the following to [`seedu.address.ui.ClientCard`](https://github.com/se-edu/addressbook-level3/commit/850b78879582f38accb05dd20c245963c65ea599#diff-639834f1e05afe2276a86372adf0fe5f69314642c2d93cfa543d614ce5a76688).
 
-**`PersonCard.java`:**
+**`ClientCard.java`:**
 
 ``` java
 @FXML
@@ -254,9 +258,9 @@ private Label remark;
 
 `@FXML` is an annotation that marks a private or protected field and makes it accessible to FXML. It might sound like Greek to you right now, don’t worry — we will get back to it later.
 
-Then insert the following into [`main/resources/view/PersonListCard.fxml`](https://github.com/se-edu/addressbook-level3/commit/850b78879582f38accb05dd20c245963c65ea599#diff-d44c4f51c24f6253c277a2bb9bc440b8064d9c15ad7cb7ceda280bca032efce9).
+Then insert the following into [`main/resources/view/ClientListCard.fxml`](https://github.com/se-edu/addressbook-level3/commit/850b78879582f38accb05dd20c245963c65ea599#diff-d44c4f51c24f6253c277a2bb9bc440b8064d9c15ad7cb7ceda280bca032efce9).
 
-**`PersonListCard.fxml`:**
+**`ClientListCard.fxml`:**
 
 ``` xml
 <Label fx:id="remark" styleClass="cell_small_label" text="\$remark" />
@@ -266,21 +270,21 @@ That’s it! Fire up the application again and you should see something like thi
 
 ![$remark shows up in each entry](../images/add-remark/$Remark.png)
 
-## Modify `Person` to support a `Remark` field
+## Modify `Client` to support a `Remark` field
 
-Since `PersonCard` displays data from a `Person`, we need to update `Person` to get our `Remark` displayed!
+Since `ClientCard` displays data from a `Client`, we need to update `Client` to get our `Remark` displayed!
 
-### Modify `Person`
+### Modify `Client`
 
-We change the constructor of `Person` to take a `Remark`. We will also need to define new fields and accessors accordingly to store our new addition.
+We change the constructor of `Client` to take a `Remark`. We will also need to define new fields and accessors accordingly to store our new addition.
 
-### Update other usages of `Person`
+### Update other usages of `Client`
 
-Unfortunately, a change to `Person` will cause other commands to break, you will have to modify these commands to use the updated `Person`!
+Unfortunately, a change to `Client` will cause other commands to break, you will have to modify these commands to use the updated `Client`!
 
 <div markdown="span" class="alert alert-primary">
 
-:bulb: Use the `Find Usages` feature in IntelliJ IDEA on the `Person` class to find these commands.
+:bulb: Use the `Find Usages` feature in IntelliJ IDEA on the `Client` class to find these commands.
 
 </div>
 
@@ -289,7 +293,7 @@ Refer to [this commit](https://github.com/se-edu/addressbook-level3/commit/ce998
 
 ## Updating Storage
 
-AddressBook stores data by serializing `JsonAdaptedPerson` into `json` with the help of an external library — Jackson. Let’s update `JsonAdaptedPerson` to work with our new `Person`!
+AddressBook stores data by serializing `JsonAdaptedClient` into `json` with the help of an external library — Jackson. Let’s update `JsonAdaptedClient` to work with our new `Client`!
 
 While the changes to code may be minimal, the test data will have to be updated as well.
 
@@ -304,14 +308,18 @@ to see what the changes entail.
 
 ## Finalizing the UI
 
-Now that we have finalized the `Person` class and its dependencies, we can now bind the `Remark` field to the UI.
+Now that we have finalized the `Client` class and its dependencies, we can now bind the `Remark` field to the UI.
 
 Just add [this one line of code!](https://github.com/se-edu/addressbook-level3/commit/5b98fee11b6b3f5749b6b943c4f3bd3aa049b692)
 
-**`PersonCard.java`:**
+**`ClientCard.java`:**
 
 ``` java
+<<<<<<< HEAD
 public PersonCard(Person client, int displayedIndex) {
+=======
+public ClientCard(Client client, int displayedIndex) {
+>>>>>>> branch-person-to-client
     //...
     remark.setText(client.getRemark().value);
 }
@@ -325,24 +333,25 @@ After the previous step, we notice a peculiar regression — we went from di
 
 ### Update `RemarkCommand` and `RemarkCommandParser`
 
-In this last step, we modify `RemarkCommand#execute()` to change the `Remark` of a `Person`. Since all fields in a `Person` are immutable, we create a new instance of a `Person` with the values that we want and
-save it with `Model#setPerson()`.
+In this last step, we modify `RemarkCommand#execute()` to change the `Remark` of a `Client`. Since all fields in a `Client` are immutable, we create a new instance of a `Client` with the values that we want and
+save it with `Model#setClient()`.
 
 **`RemarkCommand.java`:**
 
 ``` java
 //...
-    public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Person: %1$s";
-    public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Person: %1$s";
+    public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Client: %1$s";
+    public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Client: %1$s";
 //...
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Client> lastShownList = model.getFilteredClientList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
         }
 
+<<<<<<< HEAD
         Person clientToEdit = lastShownList.get(index.getZeroBased());
         Person editedClient = new Person(
                 clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
@@ -350,6 +359,15 @@ save it with `Model#setPerson()`.
 
         model.setPerson(clientToEdit, editedClient);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+=======
+        Client clientToEdit = lastShownList.get(index.getZeroBased());
+        Client editedClient = new Client(
+                clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
+                clientToEdit.getAddress(), remark, clientToEdit.getTags());
+
+        model.setClient(clientToEdit, editedClient);
+        model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
+>>>>>>> branch-person-to-client
 
         return new CommandResult(generateSuccessMessage(editedClient));
     }
@@ -359,7 +377,11 @@ save it with `Model#setPerson()`.
      * the remark is added to or removed from
      * {@code clientToEdit}.
      */
+<<<<<<< HEAD
     private String generateSuccessMessage(Person clientToEdit) {
+=======
+    private String generateSuccessMessage(Client clientToEdit) {
+>>>>>>> branch-person-to-client
         String message = !remark.value.isEmpty() ? MESSAGE_ADD_REMARK_SUCCESS : MESSAGE_DELETE_REMARK_SUCCESS;
         return String.format(message, clientToEdit);
     }

--- a/docs/tutorials/AddRemark.md
+++ b/docs/tutorials/AddRemark.md
@@ -28,7 +28,7 @@ package seedu.address.logic.commands;
 import seedu.address.model.Model;
 
 /**
- * Changes the remark of an existing client in the address book.
+ * Changes the remark of an existing person in the address book.
  */
 public class RemarkCommand extends Command {
 
@@ -65,8 +65,8 @@ Following the convention in other commands, we add relevant messages as constant
 
 ``` java
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Edits the remark of the client identified "
-            + "by the index number used in the last client listing. "
+            + ": Edits the remark of the person identified "
+            + "by the index number used in the last person listing. "
             + "Existing remark will be overwritten by the input.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "r/ [REMARK]\n"
@@ -101,8 +101,8 @@ public class RemarkCommand extends Command {
     private final String remark;
 
     /**
-     * @param index of the client in the filtered client list to edit the remark
-     * @param remark of the client to be updated to
+     * @param index of the person in the filtered person list to edit the remark
+     * @param remark of the person to be updated to
      */
     public RemarkCommand(Index index, String remark) {
         requireAllNonNull(index, remark);
@@ -225,15 +225,11 @@ If you are stuck, check out the sample
 
 ## Add `Remark` to the model
 
-<<<<<<< HEAD
-Now that we have all the information that we need, let’s lay the groundwork for propagating the remarks added into the in-memory storage of client data. We achieve that by working with the `Person` model. Each field in a Person is implemented as a separate class (e.g. a `Name` object represents the client’s name). That means we should add a `Remark` class so that we can use a `Remark` object to represent a remark given to a client.
-=======
-Now that we have all the information that we need, let’s lay the groundwork for propagating the remarks added into the in-memory storage of client data. We achieve that by working with the `Client` model. Each field in a Client is implemented as a separate class (e.g. a `Name` object represents the client’s name). That means we should add a `Remark` class so that we can use a `Remark` object to represent a remark given to a client.
->>>>>>> branch-person-to-client
+Now that we have all the information that we need, let’s lay the groundwork for propagating the remarks added into the in-memory storage of person data. We achieve that by working with the `Person` model. Each field in a Person is implemented as a separate class (e.g. a `Name` object represents the person’s name). That means we should add a `Remark` class so that we can use a `Remark` object to represent a remark given to a person.
 
 ### Add a new `Remark` class
 
-Create a new `Remark` in `seedu.address.model.client`. Since a `Remark` is a field that is similar to `Address`, we can reuse a significant bit of code.
+Create a new `Remark` in `seedu.address.model.person`. Since a `Remark` is a field that is similar to `Address`, we can reuse a significant bit of code.
 
 A copy-paste and search-replace later, you should have something like [this](https://github.com/se-edu/addressbook-level3/commit/4516e099699baa9e2d51801bd26f016d812dedcc#diff-41bb13c581e280c686198251ad6cc337cd5e27032772f06ed9bf7f1440995ece). Note how `Remark` has no constrains and thus does not require input
 validation.
@@ -244,11 +240,11 @@ Let’s change `RemarkCommand` and `RemarkCommandParser` to use the new `Remark`
 
 ## Add a placeholder element for remark to the UI
 
-Without getting too deep into `fxml`, let’s go on a 5 minute adventure to get some placeholder text to show up for each client.
+Without getting too deep into `fxml`, let’s go on a 5 minute adventure to get some placeholder text to show up for each person.
 
-Simply add the following to [`seedu.address.ui.ClientCard`](https://github.com/se-edu/addressbook-level3/commit/850b78879582f38accb05dd20c245963c65ea599#diff-639834f1e05afe2276a86372adf0fe5f69314642c2d93cfa543d614ce5a76688).
+Simply add the following to [`seedu.address.ui.PersonCard`](https://github.com/se-edu/addressbook-level3/commit/850b78879582f38accb05dd20c245963c65ea599#diff-639834f1e05afe2276a86372adf0fe5f69314642c2d93cfa543d614ce5a76688).
 
-**`ClientCard.java`:**
+**`PersonCard.java`:**
 
 ``` java
 @FXML
@@ -258,9 +254,9 @@ private Label remark;
 
 `@FXML` is an annotation that marks a private or protected field and makes it accessible to FXML. It might sound like Greek to you right now, don’t worry — we will get back to it later.
 
-Then insert the following into [`main/resources/view/ClientListCard.fxml`](https://github.com/se-edu/addressbook-level3/commit/850b78879582f38accb05dd20c245963c65ea599#diff-d44c4f51c24f6253c277a2bb9bc440b8064d9c15ad7cb7ceda280bca032efce9).
+Then insert the following into [`main/resources/view/PersonListCard.fxml`](https://github.com/se-edu/addressbook-level3/commit/850b78879582f38accb05dd20c245963c65ea599#diff-d44c4f51c24f6253c277a2bb9bc440b8064d9c15ad7cb7ceda280bca032efce9).
 
-**`ClientListCard.fxml`:**
+**`PersonListCard.fxml`:**
 
 ``` xml
 <Label fx:id="remark" styleClass="cell_small_label" text="\$remark" />
@@ -270,21 +266,21 @@ That’s it! Fire up the application again and you should see something like thi
 
 ![$remark shows up in each entry](../images/add-remark/$Remark.png)
 
-## Modify `Client` to support a `Remark` field
+## Modify `Person` to support a `Remark` field
 
-Since `ClientCard` displays data from a `Client`, we need to update `Client` to get our `Remark` displayed!
+Since `PersonCard` displays data from a `Person`, we need to update `Person` to get our `Remark` displayed!
 
-### Modify `Client`
+### Modify `Person`
 
-We change the constructor of `Client` to take a `Remark`. We will also need to define new fields and accessors accordingly to store our new addition.
+We change the constructor of `Person` to take a `Remark`. We will also need to define new fields and accessors accordingly to store our new addition.
 
-### Update other usages of `Client`
+### Update other usages of `Person`
 
-Unfortunately, a change to `Client` will cause other commands to break, you will have to modify these commands to use the updated `Client`!
+Unfortunately, a change to `Person` will cause other commands to break, you will have to modify these commands to use the updated `Person`!
 
 <div markdown="span" class="alert alert-primary">
 
-:bulb: Use the `Find Usages` feature in IntelliJ IDEA on the `Client` class to find these commands.
+:bulb: Use the `Find Usages` feature in IntelliJ IDEA on the `Person` class to find these commands.
 
 </div>
 
@@ -293,7 +289,7 @@ Refer to [this commit](https://github.com/se-edu/addressbook-level3/commit/ce998
 
 ## Updating Storage
 
-AddressBook stores data by serializing `JsonAdaptedClient` into `json` with the help of an external library — Jackson. Let’s update `JsonAdaptedClient` to work with our new `Client`!
+AddressBook stores data by serializing `JsonAdaptedPerson` into `json` with the help of an external library — Jackson. Let’s update `JsonAdaptedPerson` to work with our new `Person`!
 
 While the changes to code may be minimal, the test data will have to be updated as well.
 
@@ -308,20 +304,16 @@ to see what the changes entail.
 
 ## Finalizing the UI
 
-Now that we have finalized the `Client` class and its dependencies, we can now bind the `Remark` field to the UI.
+Now that we have finalized the `Person` class and its dependencies, we can now bind the `Remark` field to the UI.
 
 Just add [this one line of code!](https://github.com/se-edu/addressbook-level3/commit/5b98fee11b6b3f5749b6b943c4f3bd3aa049b692)
 
-**`ClientCard.java`:**
+**`PersonCard.java`:**
 
 ``` java
-<<<<<<< HEAD
-public PersonCard(Person client, int displayedIndex) {
-=======
-public ClientCard(Client client, int displayedIndex) {
->>>>>>> branch-person-to-client
+public PersonCard(Person person, int displayedIndex) {
     //...
-    remark.setText(client.getRemark().value);
+    remark.setText(person.getRemark().value);
 }
 ```
 
@@ -333,57 +325,43 @@ After the previous step, we notice a peculiar regression — we went from di
 
 ### Update `RemarkCommand` and `RemarkCommandParser`
 
-In this last step, we modify `RemarkCommand#execute()` to change the `Remark` of a `Client`. Since all fields in a `Client` are immutable, we create a new instance of a `Client` with the values that we want and
-save it with `Model#setClient()`.
+In this last step, we modify `RemarkCommand#execute()` to change the `Remark` of a `Person`. Since all fields in a `Person` are immutable, we create a new instance of a `Person` with the values that we want and
+save it with `Model#setPerson()`.
 
 **`RemarkCommand.java`:**
 
 ``` java
 //...
-    public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Client: %1$s";
-    public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Client: %1$s";
+    public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Person: %1$s";
+    public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Person: %1$s";
 //...
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-<<<<<<< HEAD
-        Person clientToEdit = lastShownList.get(index.getZeroBased());
-        Person editedClient = new Person(
-                clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
-                clientToEdit.getAddress(), remark, clientToEdit.getTags());
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+        Person editedPerson = new Person(
+                personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), remark, personToEdit.getTags());
 
-        model.setPerson(clientToEdit, editedClient);
+        model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-=======
-        Client clientToEdit = lastShownList.get(index.getZeroBased());
-        Client editedClient = new Client(
-                clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
-                clientToEdit.getAddress(), remark, clientToEdit.getTags());
 
-        model.setClient(clientToEdit, editedClient);
-        model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
->>>>>>> branch-person-to-client
-
-        return new CommandResult(generateSuccessMessage(editedClient));
+        return new CommandResult(generateSuccessMessage(editedPerson));
     }
 
     /**
      * Generates a command execution success message based on whether
      * the remark is added to or removed from
-     * {@code clientToEdit}.
+     * {@code personToEdit}.
      */
-<<<<<<< HEAD
-    private String generateSuccessMessage(Person clientToEdit) {
-=======
-    private String generateSuccessMessage(Client clientToEdit) {
->>>>>>> branch-person-to-client
+    private String generateSuccessMessage(Person personToEdit) {
         String message = !remark.value.isEmpty() ? MESSAGE_ADD_REMARK_SUCCESS : MESSAGE_DELETE_REMARK_SUCCESS;
-        return String.format(message, clientToEdit);
+        return String.format(message, personToEdit);
     }
 ```
 

--- a/docs/tutorials/RemovingFields.md
+++ b/docs/tutorials/RemovingFields.md
@@ -8,7 +8,7 @@ title: "Tutorial: Removing Fields"
 > —  Antoine de Saint-Exupery
 
 When working on an existing code base, you will most likely find that some features that are no longer necessary.
-This tutorial aims to give you some practice on such a code 'removal' activity by removing the `address` field from `Person` class.
+This tutorial aims to give you some practice on such a code 'removal' activity by removing the `address` field from `Client` class.
 
 <div markdown="span" class="alert alert-success">
 
@@ -28,7 +28,11 @@ IntelliJ IDEA provides a refactoring tool that can identify *most* parts of a re
 
 ### Assisted refactoring
 
+<<<<<<< HEAD
 The `address` field in `Person` is actually an instance of the `seedu.address.model.client.Address` class. Since removing the `Address` class will break the application, we start by identifying `Address`'s usages. This allows us to see code that depends on `Address` to function properly and edit them on a case-by-case basis. Right-click the `Address` class and select `Refactor` \> `Safe Delete` through the menu.
+=======
+The `address` field in `Client` is actually an instance of the `seedu.address.model.client.Address` class. Since removing the `Address` class will break the application, we start by identifying `Address`'s usages. This allows us to see code that depends on `Address` to function properly and edit them on a case-by-case basis. Right-click the `Address` class and select `Refactor` \> `Safe Delete` through the menu.
+>>>>>>> branch-person-to-client
 * :bulb: To make things simpler, you can unselect the options `Search in comments and strings` and `Search for text occurrences`
 
 ![Usages detected](../images/remove/UnsafeDelete.png)
@@ -37,11 +41,11 @@ Choose to `View Usages` and you should be presented with a list of `Safe Delete 
 
 ![List of conflicts](../images/remove/SafeDeleteConflicts.png)
 
-Remove usages of `Address` by performing `Safe Delete`s on each entry i.e., double-click on the entry (which takes you to the code in concern, right-click on that entity, and choose `Refactor` -> `Safe delete` as before). You will need to exercise discretion when removing usages of `Address`. Functions like `ParserUtil#parseAddress()` can be safely removed but its usages must be removed as well. Other usages like in `EditPersonDescriptor` may require more careful inspection.
+Remove usages of `Address` by performing `Safe Delete`s on each entry i.e., double-click on the entry (which takes you to the code in concern, right-click on that entity, and choose `Refactor` -> `Safe delete` as before). You will need to exercise discretion when removing usages of `Address`. Functions like `ParserUtil#parseAddress()` can be safely removed but its usages must be removed as well. Other usages like in `EditClientDescriptor` may require more careful inspection.
 
-Let’s try removing references to `Address` in `EditPersonDescriptor`.
+Let’s try removing references to `Address` in `EditClientDescriptor`.
 
-1. Safe delete the field `address` in `EditPersonDescriptor`.
+1. Safe delete the field `address` in `EditClientDescriptor`.
 
 1. Select `Yes` when prompted to remove getters and setters.
 
@@ -52,7 +56,7 @@ Let’s try removing references to `Address` in `EditPersonDescriptor`.
 
    <div markdown="span" class="alert alert-primary">
 
-   :bulb: **Tip:** Removing usages may result in errors. Exercise discretion and fix them. For example, removing the `address` field from the `Person` class will require you to modify its constructor.
+   :bulb: **Tip:** Removing usages may result in errors. Exercise discretion and fix them. For example, removing the `address` field from the `Client` class will require you to modify its constructor.
    </div>
 
 1. Repeat the steps for the remaining usages of `Address`
@@ -63,13 +67,13 @@ After you are done, verify that the application still works by compiling and run
 
 Unfortunately, there are usages of `Address` that IntelliJ IDEA cannot identify. You can find them by searching for instances of the word `address` in your code (`Edit` \> `Find` \> `Find in path`).
 
-Places of interest to look out for would be resources used by the application. `main/resources` contains images and `fxml` files used by the application and `test/resources` contains test data. For example, there is a `$address` in each `PersonCard` that has not been removed nor identified.
+Places of interest to look out for would be resources used by the application. `main/resources` contains images and `fxml` files used by the application and `test/resources` contains test data. For example, there is a `$address` in each `ClientCard` that has not been removed nor identified.
 
 ![$address](../images/remove/$address.png)
 
-A quick look at the `PersonCard` class and its `fxml` file quickly reveals why it slipped past the automated refactoring.
+A quick look at the `ClientCard` class and its `fxml` file quickly reveals why it slipped past the automated refactoring.
 
-**`PersonCard.java`**
+**`ClientCard.java`**
 
 ``` java
 ...
@@ -78,7 +82,7 @@ private Label address;
 ...
 ```
 
-**`PersonCard.fxml`**
+**`ClientCard.fxml`**
 
 ``` xml
 ...
@@ -96,12 +100,16 @@ At this point, your application is working as intended and all your tests are pa
 
 In `src/test/data/`, data meant for testing purposes are stored. While keeping the `address` field in the json files does not cause the tests to fail, it is not good practice to let cruft from old features accumulate.
 
-**`invalidPersonAddressBook.json`:**
+**`invalidClientAddressBook.json`:**
 
 ```json
 {
   "clients": [ {
+<<<<<<< HEAD
     "name": "Person with invalid name field: Ha!ns Mu@ster",
+=======
+    "name": "Client with invalid name field: Ha!ns Mu@ster",
+>>>>>>> branch-person-to-client
     "phone": "9482424",
     "email": "hans@example.com",
     "address": "4th street"

--- a/docs/tutorials/RemovingFields.md
+++ b/docs/tutorials/RemovingFields.md
@@ -8,7 +8,7 @@ title: "Tutorial: Removing Fields"
 > —  Antoine de Saint-Exupery
 
 When working on an existing code base, you will most likely find that some features that are no longer necessary.
-This tutorial aims to give you some practice on such a code 'removal' activity by removing the `address` field from `Client` class.
+This tutorial aims to give you some practice on such a code 'removal' activity by removing the `address` field from `Person` class.
 
 <div markdown="span" class="alert alert-success">
 
@@ -28,11 +28,7 @@ IntelliJ IDEA provides a refactoring tool that can identify *most* parts of a re
 
 ### Assisted refactoring
 
-<<<<<<< HEAD
-The `address` field in `Person` is actually an instance of the `seedu.address.model.client.Address` class. Since removing the `Address` class will break the application, we start by identifying `Address`'s usages. This allows us to see code that depends on `Address` to function properly and edit them on a case-by-case basis. Right-click the `Address` class and select `Refactor` \> `Safe Delete` through the menu.
-=======
-The `address` field in `Client` is actually an instance of the `seedu.address.model.client.Address` class. Since removing the `Address` class will break the application, we start by identifying `Address`'s usages. This allows us to see code that depends on `Address` to function properly and edit them on a case-by-case basis. Right-click the `Address` class and select `Refactor` \> `Safe Delete` through the menu.
->>>>>>> branch-person-to-client
+The `address` field in `Person` is actually an instance of the `seedu.address.model.person.Address` class. Since removing the `Address` class will break the application, we start by identifying `Address`'s usages. This allows us to see code that depends on `Address` to function properly and edit them on a case-by-case basis. Right-click the `Address` class and select `Refactor` \> `Safe Delete` through the menu.
 * :bulb: To make things simpler, you can unselect the options `Search in comments and strings` and `Search for text occurrences`
 
 ![Usages detected](../images/remove/UnsafeDelete.png)
@@ -41,11 +37,11 @@ Choose to `View Usages` and you should be presented with a list of `Safe Delete 
 
 ![List of conflicts](../images/remove/SafeDeleteConflicts.png)
 
-Remove usages of `Address` by performing `Safe Delete`s on each entry i.e., double-click on the entry (which takes you to the code in concern, right-click on that entity, and choose `Refactor` -> `Safe delete` as before). You will need to exercise discretion when removing usages of `Address`. Functions like `ParserUtil#parseAddress()` can be safely removed but its usages must be removed as well. Other usages like in `EditClientDescriptor` may require more careful inspection.
+Remove usages of `Address` by performing `Safe Delete`s on each entry i.e., double-click on the entry (which takes you to the code in concern, right-click on that entity, and choose `Refactor` -> `Safe delete` as before). You will need to exercise discretion when removing usages of `Address`. Functions like `ParserUtil#parseAddress()` can be safely removed but its usages must be removed as well. Other usages like in `EditPersonDescriptor` may require more careful inspection.
 
-Let’s try removing references to `Address` in `EditClientDescriptor`.
+Let’s try removing references to `Address` in `EditPersonDescriptor`.
 
-1. Safe delete the field `address` in `EditClientDescriptor`.
+1. Safe delete the field `address` in `EditPersonDescriptor`.
 
 1. Select `Yes` when prompted to remove getters and setters.
 
@@ -56,7 +52,7 @@ Let’s try removing references to `Address` in `EditClientDescriptor`.
 
    <div markdown="span" class="alert alert-primary">
 
-   :bulb: **Tip:** Removing usages may result in errors. Exercise discretion and fix them. For example, removing the `address` field from the `Client` class will require you to modify its constructor.
+   :bulb: **Tip:** Removing usages may result in errors. Exercise discretion and fix them. For example, removing the `address` field from the `Person` class will require you to modify its constructor.
    </div>
 
 1. Repeat the steps for the remaining usages of `Address`
@@ -67,13 +63,13 @@ After you are done, verify that the application still works by compiling and run
 
 Unfortunately, there are usages of `Address` that IntelliJ IDEA cannot identify. You can find them by searching for instances of the word `address` in your code (`Edit` \> `Find` \> `Find in path`).
 
-Places of interest to look out for would be resources used by the application. `main/resources` contains images and `fxml` files used by the application and `test/resources` contains test data. For example, there is a `$address` in each `ClientCard` that has not been removed nor identified.
+Places of interest to look out for would be resources used by the application. `main/resources` contains images and `fxml` files used by the application and `test/resources` contains test data. For example, there is a `$address` in each `PersonCard` that has not been removed nor identified.
 
 ![$address](../images/remove/$address.png)
 
-A quick look at the `ClientCard` class and its `fxml` file quickly reveals why it slipped past the automated refactoring.
+A quick look at the `PersonCard` class and its `fxml` file quickly reveals why it slipped past the automated refactoring.
 
-**`ClientCard.java`**
+**`PersonCard.java`**
 
 ``` java
 ...
@@ -82,7 +78,7 @@ private Label address;
 ...
 ```
 
-**`ClientCard.fxml`**
+**`PersonCard.fxml`**
 
 ``` xml
 ...
@@ -100,16 +96,12 @@ At this point, your application is working as intended and all your tests are pa
 
 In `src/test/data/`, data meant for testing purposes are stored. While keeping the `address` field in the json files does not cause the tests to fail, it is not good practice to let cruft from old features accumulate.
 
-**`invalidClientAddressBook.json`:**
+**`invalidPersonAddressBook.json`:**
 
 ```json
 {
-  "clients": [ {
-<<<<<<< HEAD
+  "persons": [ {
     "name": "Person with invalid name field: Ha!ns Mu@ster",
-=======
-    "name": "Client with invalid name field: Ha!ns Mu@ster",
->>>>>>> branch-person-to-client
     "phone": "9482424",
     "email": "hans@example.com",
     "address": "4th street"

--- a/docs/tutorials/TracingCode.md
+++ b/docs/tutorials/TracingCode.md
@@ -171,7 +171,7 @@ Recall from the User Guide that the `edit` command has the format: `edit INDEX [
 
 1. Stepping through the method shows that it calls `ArgumentTokenizer#tokenize()` and `ParserUtil#parseIndex()` to obtain the arguments and index required.
 
-1. The rest of the method seems to exhaustively check for the existence of each possible parameter of the `edit` command and store any possible changes in an `EditClientDescriptor`. Recall that we can verify the contents of `editClientDesciptor` through the 'Variables' window.<br>
+1. The rest of the method seems to exhaustively check for the existence of each possible parameter of the `edit` command and store any possible changes in an `EditPersonDescriptor`. Recall that we can verify the contents of `editPersonDesciptor` through the 'Variables' window.<br>
    ![EditCommand](../images/tracing/EditCommand.png)
 
 1. As you just traced through some code involved in parsing a command, you can take a look at this class diagram to see where the various parsing-related classes you encountered fit into the design of the `Logic` component.
@@ -189,38 +189,22 @@ Recall from the User Guide that the `edit` command has the format: `edit INDEX [
    @Override
    public CommandResult execute(Model model) throws CommandException {
        ...
-<<<<<<< HEAD
-       Person clientToEdit = lastShownList.get(index.getZeroBased());
-       Person editedClient = createEditedPerson(clientToEdit, editPersonDescriptor);
-       if (!clientToEdit.isSamePerson(editedClient) && model.hasPerson(editedClient)) {
+       Person personToEdit = lastShownList.get(index.getZeroBased());
+       Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+       if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
        }
-       model.setPerson(clientToEdit, editedClient);
+       model.setPerson(personToEdit, editedPerson);
        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-       return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedClient));
-=======
-       Client clientToEdit = lastShownList.get(index.getZeroBased());
-       Client editedClient = createEditedClient(clientToEdit, editClientDescriptor);
-       if (!clientToEdit.isSameClient(editedClient) && model.hasClient(editedClient)) {
-           throw new CommandException(MESSAGE_DUPLICATE_CLIENT);
-       }
-       model.setClient(clientToEdit, editedClient);
-       model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
-       return new CommandResult(String.format(MESSAGE_EDIT_CLIENT_SUCCESS, editedClient));
->>>>>>> branch-person-to-client
+       return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
    }
    ```
 
 1. As suspected, `command#execute()` does indeed make changes to the `model` object. Specifically,
-<<<<<<< HEAD
-   * it uses the `setPerson()` method (defined in the interface `Model` and implemented in `ModelManager` as per the usual pattern) to update the client data.
-   * it uses the `updateFilteredPersonList` method to ask the `Model` to populate the 'filtered list' with _all_ clients.<br>
-=======
-   * it uses the `setClient()` method (defined in the interface `Model` and implemented in `ModelManager` as per the usual pattern) to update the client data.
-   * it uses the `updateFilteredClientList` method to ask the `Model` to populate the 'filtered list' with _all_ clients.<br>
->>>>>>> branch-person-to-client
-     FYI, The 'filtered list' is the list of clients resulting from the most recent operation that will be shown to the user immediately after. For the `edit` command, we populate it with all the clients so that the user can see the edited client along with all other clients. If this was a `find` command, we would be setting that list to contain the search results instead.<br>
-     To provide some context, given below is the class diagram of the `Model` component. See if you can figure out where the 'filtered list' of clients is being tracked.
+   * it uses the `setPerson()` method (defined in the interface `Model` and implemented in `ModelManager` as per the usual pattern) to update the person data.
+   * it uses the `updateFilteredPersonList` method to ask the `Model` to populate the 'filtered list' with _all_ persons.<br>
+     FYI, The 'filtered list' is the list of persons resulting from the most recent operation that will be shown to the user immediately after. For the `edit` command, we populate it with all the persons so that the user can see the edited person along with all other persons. If this was a `find` command, we would be setting that list to contain the search results instead.<br>
+     To provide some context, given below is the class diagram of the `Model` component. See if you can figure out where the 'filtered list' of persons is being tracked.
      <img src="../images/ModelClassDiagram.png" width="450" /><br>
    * :bulb: This may be a good time to read through the [`Model` component section of the DG](../DeveloperGuide.html#model-component)
 
@@ -247,19 +231,15 @@ Recall from the User Guide that the `edit` command has the format: `edit INDEX [
      * {@code JsonSerializableAddressBook}.
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
-        clients.addAll(
-<<<<<<< HEAD
+        persons.addAll(
             source.getPersonList()
-=======
-            source.getClientList()
->>>>>>> branch-person-to-client
                   .stream()
-                  .map(JsonAdaptedClient::new)
+                  .map(JsonAdaptedPerson::new)
                   .collect(Collectors.toList()));
     }
     ```
 
-1. It appears that a `JsonAdaptedClient` is created for each `Client` and then added to the `JsonSerializableAddressBook`.
+1. It appears that a `JsonAdaptedPerson` is created for each `Person` and then added to the `JsonSerializableAddressBook`.
    This is because regular Java objects need to go through an _adaptation_ for them to be suitable to be saved in JSON format.
 
 1. While you are stepping through the classes in the `Storage` component, here is the component's class diagram to help you understand how those classes fit into the structure of the component.<br>
@@ -316,6 +296,6 @@ Here are some quick questions you can try to answer based on your execution path
 
     4.  Add a new command
 
-    5.  Add a new field to `Client`
+    5.  Add a new field to `Person`
 
     6.  Add a new entity to the address book

--- a/docs/tutorials/TracingCode.md
+++ b/docs/tutorials/TracingCode.md
@@ -171,7 +171,7 @@ Recall from the User Guide that the `edit` command has the format: `edit INDEX [
 
 1. Stepping through the method shows that it calls `ArgumentTokenizer#tokenize()` and `ParserUtil#parseIndex()` to obtain the arguments and index required.
 
-1. The rest of the method seems to exhaustively check for the existence of each possible parameter of the `edit` command and store any possible changes in an `EditPersonDescriptor`. Recall that we can verify the contents of `editPersonDesciptor` through the 'Variables' window.<br>
+1. The rest of the method seems to exhaustively check for the existence of each possible parameter of the `edit` command and store any possible changes in an `EditClientDescriptor`. Recall that we can verify the contents of `editClientDesciptor` through the 'Variables' window.<br>
    ![EditCommand](../images/tracing/EditCommand.png)
 
 1. As you just traced through some code involved in parsing a command, you can take a look at this class diagram to see where the various parsing-related classes you encountered fit into the design of the `Logic` component.
@@ -189,6 +189,7 @@ Recall from the User Guide that the `edit` command has the format: `edit INDEX [
    @Override
    public CommandResult execute(Model model) throws CommandException {
        ...
+<<<<<<< HEAD
        Person clientToEdit = lastShownList.get(index.getZeroBased());
        Person editedClient = createEditedPerson(clientToEdit, editPersonDescriptor);
        if (!clientToEdit.isSamePerson(editedClient) && model.hasPerson(editedClient)) {
@@ -197,12 +198,27 @@ Recall from the User Guide that the `edit` command has the format: `edit INDEX [
        model.setPerson(clientToEdit, editedClient);
        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedClient));
+=======
+       Client clientToEdit = lastShownList.get(index.getZeroBased());
+       Client editedClient = createEditedClient(clientToEdit, editClientDescriptor);
+       if (!clientToEdit.isSameClient(editedClient) && model.hasClient(editedClient)) {
+           throw new CommandException(MESSAGE_DUPLICATE_CLIENT);
+       }
+       model.setClient(clientToEdit, editedClient);
+       model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
+       return new CommandResult(String.format(MESSAGE_EDIT_CLIENT_SUCCESS, editedClient));
+>>>>>>> branch-person-to-client
    }
    ```
 
 1. As suspected, `command#execute()` does indeed make changes to the `model` object. Specifically,
+<<<<<<< HEAD
    * it uses the `setPerson()` method (defined in the interface `Model` and implemented in `ModelManager` as per the usual pattern) to update the client data.
    * it uses the `updateFilteredPersonList` method to ask the `Model` to populate the 'filtered list' with _all_ clients.<br>
+=======
+   * it uses the `setClient()` method (defined in the interface `Model` and implemented in `ModelManager` as per the usual pattern) to update the client data.
+   * it uses the `updateFilteredClientList` method to ask the `Model` to populate the 'filtered list' with _all_ clients.<br>
+>>>>>>> branch-person-to-client
      FYI, The 'filtered list' is the list of clients resulting from the most recent operation that will be shown to the user immediately after. For the `edit` command, we populate it with all the clients so that the user can see the edited client along with all other clients. If this was a `find` command, we would be setting that list to contain the search results instead.<br>
      To provide some context, given below is the class diagram of the `Model` component. See if you can figure out where the 'filtered list' of clients is being tracked.
      <img src="../images/ModelClassDiagram.png" width="450" /><br>
@@ -232,14 +248,18 @@ Recall from the User Guide that the `edit` command has the format: `edit INDEX [
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         clients.addAll(
+<<<<<<< HEAD
             source.getPersonList()
+=======
+            source.getClientList()
+>>>>>>> branch-person-to-client
                   .stream()
-                  .map(JsonAdaptedPerson::new)
+                  .map(JsonAdaptedClient::new)
                   .collect(Collectors.toList()));
     }
     ```
 
-1. It appears that a `JsonAdaptedPerson` is created for each `Person` and then added to the `JsonSerializableAddressBook`.
+1. It appears that a `JsonAdaptedClient` is created for each `Client` and then added to the `JsonSerializableAddressBook`.
    This is because regular Java objects need to go through an _adaptation_ for them to be suitable to be saved in JSON format.
 
 1. While you are stepping through the classes in the `Storage` component, here is the component's class diagram to help you understand how those classes fit into the structure of the component.<br>
@@ -296,6 +316,6 @@ Here are some quick questions you can try to answer based on your execution path
 
     4.  Add a new command
 
-    5.  Add a new field to `Person`
+    5.  Add a new field to `Client`
 
     6.  Add a new entity to the address book

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,7 +7,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The Client index provided is invalid";
-    public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d Clients listed!";
 
+    public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The client index provided is invalid";
+    public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d clients listed!";
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -30,7 +30,8 @@ public interface Logic {
      */
     ReadOnlyAddressBook getAddressBook();
 
-    /** Returns an unmodifiable view of the filtered list of Clients */
+
+    /** Returns an unmodifiable view of the filtered list of clients */
     ObservableList<Client> getFilteredClientList();
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -12,11 +12,7 @@ import seedu.address.model.Model;
 import seedu.address.model.client.Client;
 
 /**
-<<<<<<< HEAD
- * Adds a Client to the address book.
-=======
  * Adds a client to the address book.
->>>>>>> branch-person-to-client
  */
 public class AddCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -12,13 +12,17 @@ import seedu.address.model.Model;
 import seedu.address.model.client.Client;
 
 /**
+<<<<<<< HEAD
  * Adds a Client to the address book.
+=======
+ * Adds a client to the address book.
+>>>>>>> branch-person-to-client
  */
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a Client to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a client to the address book. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
@@ -33,8 +37,8 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 
-    public static final String MESSAGE_SUCCESS = "New Client added: %1$s";
-    public static final String MESSAGE_DUPLICATE_CLIENT = "This Client already exists in the address book";
+    public static final String MESSAGE_SUCCESS = "New client added: %1$s";
+    public static final String MESSAGE_DUPLICATE_CLIENT = "This client already exists in the address book";
 
     private final Client toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -11,11 +11,7 @@ import seedu.address.model.Model;
 import seedu.address.model.client.Client;
 
 /**
-<<<<<<< HEAD
- * Deletes a Client identified using it's displayed index from the address book.
-=======
  * Deletes a client identified using it's displayed index from the address book.
->>>>>>> branch-person-to-client
  */
 public class DeleteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -11,14 +11,18 @@ import seedu.address.model.Model;
 import seedu.address.model.client.Client;
 
 /**
+<<<<<<< HEAD
  * Deletes a Client identified using it's displayed index from the address book.
+=======
+ * Deletes a client identified using it's displayed index from the address book.
+>>>>>>> branch-person-to-client
  */
 public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the Client identified by the index number used in the displayed Client list.\n"
+            + ": Deletes the client identified by the index number used in the displayed client list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -19,19 +19,22 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.client.*;
+import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Email;
+import seedu.address.model.client.Name;
+import seedu.address.model.client.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
- * Edits the details of an existing Client in the address book.
+ * Edits the details of an existing client in the address book.
  */
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the Client identified "
-            + "by the index number used in the displayed Client list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the client identified "
+            + "by the index number used in the displayed client list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
@@ -45,14 +48,14 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_CLIENT_SUCCESS = "Edited Client: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_CLIENT = "This Client already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_CLIENT = "This client already exists in the address book.";
 
     private final Index index;
     private final EditClientDescriptor editClientDescriptor;
 
     /**
-     * @param index of the Client in the filtered Client list to edit
-     * @param editClientDescriptor details to edit the Client with
+     * @param index of the client in the filtered client list to edit
+     * @param editClientDescriptor details to edit the client with
      */
     public EditCommand(Index index, EditClientDescriptor editClientDescriptor) {
         requireNonNull(index);
@@ -84,7 +87,7 @@ public class EditCommand extends Command {
     }
 
     /**
-     * Creates and returns a {@code Client} with the details of {@code ClientToEdit}
+     * Creates and returns a {@code Client} with the details of {@code clientToEdit}
      * edited with {@code editClientDescriptor}.
      */
     private static Client createEditedClient(Client clientToEdit, EditClientDescriptor editClientDescriptor) {
@@ -118,8 +121,8 @@ public class EditCommand extends Command {
     }
 
     /**
-     * Stores the details to edit the Client with. Each non-empty field value will replace the
-     * corresponding field value of the Client.
+     * Stores the details to edit the client with. Each non-empty field value will replace the
+     * corresponding field value of the client.
      */
     public static class EditClientDescriptor {
         private Name name;

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -7,14 +7,14 @@ import seedu.address.model.Model;
 import seedu.address.model.client.NameContainsKeywordsPredicate;
 
 /**
- * Finds and lists all Clients in address book whose name contains any of the argument keywords.
+ * Finds and lists all clients in address book whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all Clients whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all clients whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -6,11 +6,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 import seedu.address.model.Model;
 
 /**
-<<<<<<< HEAD
- * Lists all Clients in the address book to the user.
-=======
  * Lists all clients in the address book to the user.
->>>>>>> branch-person-to-client
  */
 public class ListCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -6,14 +6,17 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 import seedu.address.model.Model;
 
 /**
+<<<<<<< HEAD
  * Lists all Clients in the address book to the user.
+=======
+ * Lists all clients in the address book to the user.
+>>>>>>> branch-person-to-client
  */
 public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all Clients";
-
+    public static final String MESSAGE_SUCCESS = "Listed all clients";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -13,9 +13,9 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
+import seedu.address.model.client.Client;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
-import seedu.address.model.client.Client;
 import seedu.address.model.client.Phone;
 import seedu.address.model.tag.Tag;
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -40,8 +40,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     //// list overwrite operations
 
     /**
-     * Replaces the contents of the Client list with {@code Clients}.
-     * {@code Clients} must not contain duplicate Clients.
+     * Replaces the contents of the client list with {@code clients}.
+     * {@code clients} must not contain duplicate clients.
      */
     public void setClients(List<Client> clients) {
         this.clients.setClients(clients);
@@ -56,10 +56,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         setClients(newData.getClientList());
     }
 
-    //// Client-level operations
+    //// client-level operations
 
     /**
-     * Returns true if a Client with the same identity as {@code Client} exists in the address book.
+     * Returns true if a client with the same identity as {@code client} exists in the address book.
      */
     public boolean hasClient(Client client) {
         requireNonNull(client);
@@ -67,17 +67,17 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Adds a Client to the address book.
-     * The Client must not already exist in the address book.
+     * Adds a client to the address book.
+     * The client must not already exist in the address book.
      */
     public void addClient(Client p) {
         clients.add(p);
     }
 
     /**
-     * Replaces the given Client {@code target} in the list with {@code editedClient}.
+     * Replaces the given client {@code target} in the list with {@code editedClient}.
      * {@code target} must exist in the address book.
-     * The Client identity of {@code editedClient} must not be the same as another existing Client in the address book.
+     * The client identity of {@code editedClient} must not be the same as another existing client in the address book.
      */
     public void setClient(Client target, Client editedClient) {
         requireNonNull(editedClient);
@@ -97,7 +97,7 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     @Override
     public String toString() {
-        return clients.asUnmodifiableObservableList().size() + " Clients";
+        return clients.asUnmodifiableObservableList().size() + " clients";
         // TODO: refine later
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -53,34 +53,34 @@ public interface Model {
     ReadOnlyAddressBook getAddressBook();
 
     /**
-     * Returns true if a Client with the same identity as {@code Client} exists in the address book.
+     * Returns true if a client with the same identity as {@code client} exists in the address book.
      */
     boolean hasClient(Client client);
 
     /**
-     * Deletes the given Client.
-     * The Client must exist in the address book.
+     * Deletes the given client.
+     * The client must exist in the address book.
      */
     void deleteClient(Client target);
 
     /**
-     * Adds the given Client.
-     * {@code Client} must not already exist in the address book.
+     * Adds the given client.
+     * {@code client} must not already exist in the address book.
      */
     void addClient(Client client);
 
     /**
-     * Replaces the given Client {@code target} with {@code editedClient}.
+     * Replaces the given client {@code target} with {@code editedClient}.
      * {@code target} must exist in the address book.
-     * The Client identity of {@code editedClient} must not be the same as another existing Client in the address book.
+     * The client identity of {@code editedClient} must not be the same as another existing client in the address book.
      */
     void setClient(Client target, Client editedClient);
 
-    /** Returns an unmodifiable view of the filtered Client list */
+    /** Returns an unmodifiable view of the filtered client list */
     ObservableList<Client> getFilteredClientList();
 
     /**
-     * Updates the filter of the filtered Client list to filter by the given {@code predicate}.
+     * Updates the filter of the filtered client list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredClientList(Predicate<Client> predicate);

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -9,8 +9,8 @@ import seedu.address.model.client.Client;
 public interface ReadOnlyAddressBook {
 
     /**
-     * Returns an unmodifiable view of the Clients list.
-     * This list will not contain any duplicate Clients.
+     * Returns an unmodifiable view of the clients list.
+     * This list will not contain any duplicate clients.
      */
     ObservableList<Client> getClientList();
 

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -61,8 +61,8 @@ public class Client {
     }
 
     /**
-     * Returns true if both Clients have the same name.
-     * This defines a weaker notion of equality between two Clients.
+     * Returns true if both clients have the same name.
+     * This defines a weaker notion of equality between two clients.
      */
     public boolean isSameClient(Client otherClient) {
         if (otherClient == this) {
@@ -74,8 +74,8 @@ public class Client {
     }
 
     /**
-     * Returns true if both Clients have the same identity and data fields.
-     * This defines a stronger notion of equality between two Clients.
+     * Returns true if both clients have the same identity and data fields.
+     * This defines a stronger notion of equality between two clients.
      */
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/client/UniqueClientList.java
+++ b/src/main/java/seedu/address/model/client/UniqueClientList.java
@@ -8,15 +8,15 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.model.client.exceptions.DuplicateClientException;
 import seedu.address.model.client.exceptions.ClientNotFoundException;
+import seedu.address.model.client.exceptions.DuplicateClientException;
 
 /**
- * A list of Clients that enforces uniqueness between its elements and does not allow nulls.
- * A Client is considered unique by comparing using {@code Client#isSameClient(Client)}. As such, adding and updating of
- * Clients uses Client#isSameClient(Client) for equality so as to ensure that the Client being added or updated is
- * unique in terms of identity in the UniqueClientList. However, the removal of a Client uses Client#equals(Object) so
- * as to ensure that the Client with exactly the same fields will be removed.
+ * A list of clients that enforces uniqueness between its elements and does not allow nulls.
+ * A client is considered unique by comparing using {@code Client#isSameClient(Client)}. As such, adding and updating of
+ * clients uses Client#isSameClient(Client) for equality so as to ensure that the client being added or updated is
+ * unique in terms of identity in the UniqueClientList. However, the removal of a client uses Client#equals(Object) so
+ * as to ensure that the client with exactly the same fields will be removed.
  *
  * Supports a minimal set of list operations.
  *
@@ -29,7 +29,7 @@ public class UniqueClientList implements Iterable<Client> {
             FXCollections.unmodifiableObservableList(internalList);
 
     /**
-     * Returns true if the list contains an equivalent Client as the given argument.
+     * Returns true if the list contains an equivalent client as the given argument.
      */
     public boolean contains(Client toCheck) {
         requireNonNull(toCheck);
@@ -37,8 +37,8 @@ public class UniqueClientList implements Iterable<Client> {
     }
 
     /**
-     * Adds a Client to the list.
-     * The Client must not already exist in the list.
+     * Adds a client to the list.
+     * The client must not already exist in the list.
      */
     public void add(Client toAdd) {
         requireNonNull(toAdd);
@@ -49,9 +49,9 @@ public class UniqueClientList implements Iterable<Client> {
     }
 
     /**
-     * Replaces the Client {@code target} in the list with {@code editedClient}.
+     * Replaces the client {@code target} in the list with {@code editedClient}.
      * {@code target} must exist in the list.
-     * The Client identity of {@code editedClient} must not be the same as another existing Client in the list.
+     * The client identity of {@code editedClient} must not be the same as another existing client in the list.
      */
     public void setClient(Client target, Client editedClient) {
         requireAllNonNull(target, editedClient);
@@ -69,8 +69,8 @@ public class UniqueClientList implements Iterable<Client> {
     }
 
     /**
-     * Removes the equivalent Client from the list.
-     * The Client must exist in the list.
+     * Removes the equivalent client from the list.
+     * The client must exist in the list.
      */
     public void remove(Client toRemove) {
         requireNonNull(toRemove);
@@ -85,12 +85,12 @@ public class UniqueClientList implements Iterable<Client> {
     }
 
     /**
-     * Replaces the contents of this list with {@code Clients}.
-     * {@code Clients} must not contain duplicate Clients.
+     * Replaces the contents of this list with {@code clients}.
+     * {@code clients} must not contain duplicate clients.
      */
     public void setClients(List<Client> clients) {
         requireAllNonNull(clients);
-        if (!ClientsAreUnique(clients)) {
+        if (!clientsAreUnique(clients)) {
             throw new DuplicateClientException();
         }
 
@@ -122,9 +122,9 @@ public class UniqueClientList implements Iterable<Client> {
     }
 
     /**
-     * Returns true if {@code Clients} contains only unique Clients.
+     * Returns true if {@code clients} contains only unique clients.
      */
-    private boolean ClientsAreUnique(List<Client> clients) {
+    private boolean clientsAreUnique(List<Client> clients) {
         for (int i = 0; i < clients.size() - 1; i++) {
             for (int j = i + 1; j < clients.size(); j++) {
                 if (clients.get(i).isSameClient(clients.get(j))) {

--- a/src/main/java/seedu/address/model/client/exceptions/ClientNotFoundException.java
+++ b/src/main/java/seedu/address/model/client/exceptions/ClientNotFoundException.java
@@ -1,6 +1,6 @@
 package seedu.address.model.client.exceptions;
 
 /**
- * Signals that the operation is unable to find the specified person.
+ * Signals that the operation is unable to find the specified client.
  */
 public class ClientNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/address/model/client/exceptions/DuplicateClientException.java
+++ b/src/main/java/seedu/address/model/client/exceptions/DuplicateClientException.java
@@ -1,11 +1,11 @@
 package seedu.address.model.client.exceptions;
 
 /**
- * Signals that the operation will result in duplicate Persons (Persons are considered duplicates if they have the same
+ * Signals that the operation will result in duplicate Clients (Clients are considered duplicates if they have the same
  * identity).
  */
 public class DuplicateClientException extends RuntimeException {
     public DuplicateClientException() {
-        super("Operation would result in duplicate Clients");
+        super("Operation would result in duplicate clients");
     }
 }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -6,8 +6,11 @@ import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.client.*;
+import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Email;
+import seedu.address.model.client.Name;
+import seedu.address.model.client.Phone;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -10,8 +10,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.client.*;
+import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Email;
+import seedu.address.model.client.Name;
+import seedu.address.model.client.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -28,7 +31,7 @@ class JsonAdaptedClient {
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonAdaptedClient} with the given Client details.
+     * Constructs a {@code JsonAdaptedClient} with the given client details.
      */
     @JsonCreator
     public JsonAdaptedClient(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
@@ -57,14 +60,14 @@ class JsonAdaptedClient {
     }
 
     /**
-     * Converts this Jackson-friendly adapted Client object into the model's {@code Client} object.
+     * Converts this Jackson-friendly adapted client object into the model's {@code Client} object.
      *
-     * @throws IllegalValueException if there were any data constraints violated in the adapted Client.
+     * @throws IllegalValueException if there were any data constraints violated in the adapted client.
      */
     public Client toModelType() throws IllegalValueException {
-        final List<Tag> ClientTags = new ArrayList<>();
+        final List<Tag> clientTags = new ArrayList<>();
         for (JsonAdaptedTag tag : tagged) {
-            ClientTags.add(tag.toModelType());
+            clientTags.add(tag.toModelType());
         }
 
         if (name == null) {
@@ -99,7 +102,7 @@ class JsonAdaptedClient {
         }
         final Address modelAddress = new Address(address);
 
-        final Set<Tag> modelTags = new HashSet<>(ClientTags);
+        final Set<Tag> modelTags = new HashSet<>(clientTags);
         return new Client(modelName, modelPhone, modelEmail, modelAddress, modelTags);
     }
 

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -19,16 +19,16 @@ import seedu.address.model.client.Client;
 @JsonRootName(value = "addressbook")
 class JsonSerializableAddressBook {
 
-    public static final String MESSAGE_DUPLICATE_CLIENT = "Clients list contains duplicate Client(s).";
+    public static final String MESSAGE_DUPLICATE_CLIENT = "Clients list contains duplicate client(s).";
 
-    private final List<JsonAdaptedClient> Clients = new ArrayList<>();
+    private final List<JsonAdaptedClient> clients = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonSerializableAddressBook} with the given Clients.
+     * Constructs a {@code JsonSerializableAddressBook} with the given clients.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("Clients") List<JsonAdaptedClient> Clients) {
-        this.Clients.addAll(Clients);
+    public JsonSerializableAddressBook(@JsonProperty("clients") List<JsonAdaptedClient> clients) {
+        this.clients.addAll(clients);
     }
 
     /**
@@ -37,7 +37,7 @@ class JsonSerializableAddressBook {
      * @param source future changes to this will not affect the created {@code JsonSerializableAddressBook}.
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
-        Clients.addAll(source.getClientList().stream().map(JsonAdaptedClient::new).collect(Collectors.toList()));
+        clients.addAll(source.getClientList().stream().map(JsonAdaptedClient::new).collect(Collectors.toList()));
     }
 
     /**
@@ -47,7 +47,7 @@ class JsonSerializableAddressBook {
      */
     public AddressBook toModelType() throws IllegalValueException {
         AddressBook addressBook = new AddressBook();
-        for (JsonAdaptedClient jsonAdaptedClient : Clients) {
+        for (JsonAdaptedClient jsonAdaptedClient : clients) {
             Client client = jsonAdaptedClient.toModelType();
             if (addressBook.hasClient(client)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_CLIENT);

--- a/src/main/java/seedu/address/ui/ClientListPanel.java
+++ b/src/main/java/seedu/address/ui/ClientListPanel.java
@@ -11,7 +11,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.client.Client;
 
 /**
- * Panel containing the list of Clients.
+ * Panel containing the list of clients.
  */
 public class ClientListPanel extends UiPart<Region> {
     private static final String FXML = "ClientListPanel.fxml";

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -110,7 +110,6 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        logic.getFilteredClientList();
         clientListPanel = new ClientListPanel(logic.getFilteredClientList());
         clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -328,7 +328,7 @@
     -fx-text-fill: white;
 }
 
-#filterField, #personListPanel, #personWebpage {
+#filterField, #clientListPanel, #clientWebpage {
     -fx-effect: innershadow(gaussian, black, 10, 0, 0, 0);
 }
 

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidClientAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidClientAddressBook.json
@@ -1,11 +1,11 @@
 {
-  "Clients": [ {
-    "name": "Valid Person",
+  "clients": [ {
+    "name": "Valid Client",
     "phone": "9482424",
     "email": "hans@example.com",
     "address": "4th street"
   }, {
-    "name": "Person With Invalid Phone Field",
+    "name": "Client With Invalid Phone Field",
     "phone": "948asdf2424",
     "email": "hans@example.com",
     "address": "4th street"

--- a/src/test/data/JsonAddressBookStorageTest/invalidClientAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidClientAddressBook.json
@@ -1,6 +1,6 @@
 {
-  "Clients": [ {
-    "name": "Person with invalid name field: Ha!ns Mu@ster",
+  "clients": [ {
+    "name": "Client with invalid name field: Ha!ns Mu@ster",
     "phone": "9482424",
     "email": "hans@example.com",
     "address": "4th street"

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateClientAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateClientAddressBook.json
@@ -1,5 +1,5 @@
 {
-  "Clients": [ {
+  "clients": [ {
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "alice@example.com",

--- a/src/test/data/JsonSerializableAddressBookTest/invalidClientAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidClientAddressBook.json
@@ -1,5 +1,5 @@
 {
-  "Clients": [ {
+  "clients": [ {
     "name": "Hans Muster",
     "phone": "9482424",
     "email": "invalid@email!3e",

--- a/src/test/data/JsonSerializableAddressBookTest/typicalClientsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalClientsAddressBook.json
@@ -1,6 +1,6 @@
 {
-  "_comment": "AddressBook save file which contains the same Person values as in TypicalPersons#getTypicalAddressBook()",
-  "Clients" : [ {
+  "_comment": "AddressBook save file which contains the same Client values as in TypicalClients#getTypicalAddressBook()",
+  "clients" : [ {
     "name" : "Alice Pauline",
     "phone" : "94351253",
     "email" : "alice@example.com",

--- a/src/test/java/seedu/address/commons/core/index/IndexTest.java
+++ b/src/test/java/seedu/address/commons/core/index/IndexTest.java
@@ -39,22 +39,22 @@ public class IndexTest {
 
     @Test
     public void equals() {
-        final Index fifthPersonIndex = Index.fromOneBased(5);
+        final Index fifthClientIndex = Index.fromOneBased(5);
 
         // same values -> returns true
-        assertTrue(fifthPersonIndex.equals(Index.fromOneBased(5)));
-        assertTrue(fifthPersonIndex.equals(Index.fromZeroBased(4)));
+        assertTrue(fifthClientIndex.equals(Index.fromOneBased(5)));
+        assertTrue(fifthClientIndex.equals(Index.fromZeroBased(4)));
 
         // same object -> returns true
-        assertTrue(fifthPersonIndex.equals(fifthPersonIndex));
+        assertTrue(fifthClientIndex.equals(fifthClientIndex));
 
         // null -> returns false
-        assertFalse(fifthPersonIndex.equals(null));
+        assertFalse(fifthClientIndex.equals(null));
 
         // different types -> returns false
-        assertFalse(fifthPersonIndex.equals(5.0f));
+        assertFalse(fifthClientIndex.equals(5.0f));
 
         // different index -> returns false
-        assertFalse(fifthPersonIndex.equals(Index.fromOneBased(1)));
+        assertFalse(fifthClientIndex.equals(Index.fromOneBased(1)));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -31,14 +31,14 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_ClientAcceptedByModel_addSuccessful() throws Exception {
+    public void execute_clientAcceptedByModel_addSuccessful() throws Exception {
         ModelStubAcceptingClientAdded modelStub = new ModelStubAcceptingClientAdded();
         Client validClient = new ClientBuilder().build();
 
         CommandResult commandResult = new AddCommand(validClient).execute(modelStub);
 
         assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validClient), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validClient), modelStub.ClientsAdded);
+        assertEquals(Arrays.asList(validClient), modelStub.clientsAdded);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class AddCommandTest {
         // null -> returns false
         assertFalse(addAliceCommand.equals(null));
 
-        // different Client -> returns false
+        // different client -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
     }
 
@@ -150,7 +150,7 @@ public class AddCommandTest {
     }
 
     /**
-     * A Model stub that contains a single Client.
+     * A Model stub that contains a single client.
      */
     private class ModelStubWithClient extends ModelStub {
         private final Client client;
@@ -168,21 +168,21 @@ public class AddCommandTest {
     }
 
     /**
-     * A Model stub that always accept the Client being added.
+     * A Model stub that always accept the client being added.
      */
     private class ModelStubAcceptingClientAdded extends ModelStub {
-        final ArrayList<Client> ClientsAdded = new ArrayList<>();
+        final ArrayList<Client> clientsAdded = new ArrayList<>();
 
         @Override
         public boolean hasClient(Client client) {
             requireNonNull(client);
-            return ClientsAdded.stream().anyMatch(client::isSameClient);
+            return clientsAdded.stream().anyMatch(client::isSameClient);
         }
 
         @Override
         public void addClient(Client client) {
             requireNonNull(client);
-            ClientsAdded.add(client);
+            clientsAdded.add(client);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -107,7 +107,7 @@ public class CommandTestUtil {
      * Executes the given {@code command}, confirms that <br>
      * - a {@code CommandException} is thrown <br>
      * - the CommandException message matches {@code expectedMessage} <br>
-     * - the address book, filtered Client list and selected Client in {@code actualModel} remain unchanged
+     * - the address book, filtered client list and selected client in {@code actualModel} remain unchanged
      */
     public static void assertCommandFailure(Command command, Model actualModel, String expectedMessage) {
         // we are unable to defensively copy the model for comparison later, so we can
@@ -120,7 +120,7 @@ public class CommandTestUtil {
         assertEquals(expectedFilteredList, actualModel.getFilteredClientList());
     }
     /**
-     * Updates {@code model}'s filtered list to show only the Client at the given {@code targetIndex} in the
+     * Updates {@code model}'s filtered list to show only the client at the given {@code targetIndex} in the
      * {@code model}'s address book.
      */
     public static void showClientAtIndex(Model model, Index targetIndex) {

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showClientAtIndex;
+import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CLIENT;
-import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
@@ -94,7 +94,7 @@ public class DeleteCommandTest {
         // null -> returns false
         assertFalse(deleteFirstCommand.equals(null));
 
-        // different Client -> returns false
+        // different client -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -10,9 +10,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showClientAtIndex;
+import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CLIENT;
-import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,8 +53,8 @@ public class EditCommandTest {
         Index indexLastClient = Index.fromOneBased(model.getFilteredClientList().size());
         Client lastClient = model.getFilteredClientList().get(indexLastClient.getZeroBased());
 
-        ClientBuilder ClientInList = new ClientBuilder(lastClient);
-        Client editedClient = ClientInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+        ClientBuilder clientInList = new ClientBuilder(lastClient);
+        Client editedClient = clientInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
 
         EditClientDescriptor descriptor = new EditClientDescriptorBuilder().withName(VALID_NAME_BOB)
@@ -111,7 +111,7 @@ public class EditCommandTest {
     public void execute_duplicateClientFilteredList_failure() {
         showClientAtIndex(model, INDEX_FIRST_CLIENT);
 
-        // edit Client in filtered list into a duplicate in address book
+        // edit client in filtered list into a duplicate in address book
         Client clientInList = model.getAddressBook().getClientList().get(INDEX_SECOND_CLIENT.getZeroBased());
         EditCommand editCommand = new EditCommand(INDEX_FIRST_CLIENT,
                 new EditClientDescriptorBuilder(clientInList).build());

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -50,7 +50,7 @@ public class FindCommandTest {
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
 
-        // different Client -> returns false
+        // different client -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
     }
 

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -2,8 +2,8 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showClientAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
 import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -33,9 +33,9 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.model.client.Address;
+import seedu.address.model.client.Client;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
-import seedu.address.model.client.Client;
 import seedu.address.model.client.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.ClientBuilder;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -23,11 +23,11 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.client.NameContainsKeywordsPredicate;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.NameContainsKeywordsPredicate;
 import seedu.address.testutil.ClientBuilder;
-import seedu.address.testutil.EditClientDescriptorBuilder;
 import seedu.address.testutil.ClientUtil;
+import seedu.address.testutil.EditClientDescriptorBuilder;
 
 public class AddressBookParserTest {
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -45,7 +45,7 @@ public class AddressBookTest {
 
     @Test
     public void resetData_withDuplicateClients_throwsDuplicateClientException() {
-        // Two Clients with the same identity fields
+        // Two clients with the same identity fields
         Client editedAlice = new ClientBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         List<Client> newClients = Arrays.asList(ALICE, editedAlice);
@@ -60,18 +60,18 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasClient_ClientNotInAddressBook_returnsFalse() {
+    public void hasClient_clientNotInAddressBook_returnsFalse() {
         assertFalse(addressBook.hasClient(ALICE));
     }
 
     @Test
-    public void hasClient_ClientInAddressBook_returnsTrue() {
+    public void hasClient_clientInAddressBook_returnsTrue() {
         addressBook.addClient(ALICE);
         assertTrue(addressBook.hasClient(ALICE));
     }
 
     @Test
-    public void hasClient_ClientWithSameIdentityFieldsInAddressBook_returnsTrue() {
+    public void hasClient_clientWithSameIdentityFieldsInAddressBook_returnsTrue() {
         addressBook.addClient(ALICE);
         Client editedAlice = new ClientBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
@@ -84,7 +84,7 @@ public class AddressBookTest {
     }
 
     /**
-     * A stub ReadOnlyAddressBook whose Clients list can violate interface constraints.
+     * A stub ReadOnlyAddressBook whose clients list can violate interface constraints.
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Client> clients = FXCollections.observableArrayList();

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -78,12 +78,12 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void hasClient_ClientNotInAddressBook_returnsFalse() {
+    public void hasClient_clientNotInAddressBook_returnsFalse() {
         assertFalse(modelManager.hasClient(ALICE));
     }
 
     @Test
-    public void hasClient_ClientInAddressBook_returnsTrue() {
+    public void hasClient_clientInAddressBook_returnsTrue() {
         modelManager.addClient(ALICE);
         assertTrue(modelManager.hasClient(ALICE));
     }

--- a/src/test/java/seedu/address/model/client/ClientTest.java
+++ b/src/test/java/seedu/address/model/client/ClientTest.java
@@ -65,7 +65,7 @@ public class ClientTest {
         // different type -> returns false
         assertFalse(ALICE.equals(5));
 
-        // different Client -> returns false
+        // different client -> returns false
         assertFalse(ALICE.equals(BOB));
 
         // different name -> returns false

--- a/src/test/java/seedu/address/model/client/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/client/NameContainsKeywordsPredicateTest.java
@@ -34,7 +34,7 @@ public class NameContainsKeywordsPredicateTest {
         // null -> returns false
         assertFalse(firstPredicate.equals(null));
 
-        // different Client -> returns false
+        // different client -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));
     }
 

--- a/src/test/java/seedu/address/model/client/UniqueClientListTest.java
+++ b/src/test/java/seedu/address/model/client/UniqueClientListTest.java
@@ -15,8 +15,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.model.client.exceptions.DuplicateClientException;
 import seedu.address.model.client.exceptions.ClientNotFoundException;
+import seedu.address.model.client.exceptions.DuplicateClientException;
 import seedu.address.testutil.ClientBuilder;
 
 public class UniqueClientListTest {
@@ -29,18 +29,18 @@ public class UniqueClientListTest {
     }
 
     @Test
-    public void contains_ClientNotInList_returnsFalse() {
+    public void contains_clientNotInList_returnsFalse() {
         assertFalse(uniqueClientList.contains(ALICE));
     }
 
     @Test
-    public void contains_ClientInList_returnsTrue() {
+    public void contains_clientInList_returnsTrue() {
         uniqueClientList.add(ALICE);
         assertTrue(uniqueClientList.contains(ALICE));
     }
 
     @Test
-    public void contains_ClientWithSameIdentityFieldsInList_returnsTrue() {
+    public void contains_clientWithSameIdentityFieldsInList_returnsTrue() {
         uniqueClientList.add(ALICE);
         Client editedAlice = new ClientBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
@@ -115,7 +115,7 @@ public class UniqueClientListTest {
     }
 
     @Test
-    public void remove_ClientDoesNotExist_throwsClientNotFoundException() {
+    public void remove_clientDoesNotExist_throwsClientNotFoundException() {
         assertThrows(ClientNotFoundException.class, () -> uniqueClientList.remove(ALICE));
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
@@ -34,77 +34,77 @@ public class JsonAdaptedClientTest {
 
     @Test
     public void toModelType_validClientDetails_returnsClient() throws Exception {
-        JsonAdaptedClient Client = new JsonAdaptedClient(BENSON);
-        assertEquals(BENSON, Client.toModelType());
+        JsonAdaptedClient client = new JsonAdaptedClient(BENSON);
+        assertEquals(BENSON, client.toModelType());
     }
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedClient Client =
+        JsonAdaptedClient client =
                 new JsonAdaptedClient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, Client::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedClient Client = new JsonAdaptedClient(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedClient client = new JsonAdaptedClient(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, Client::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
-        JsonAdaptedClient Client =
+        JsonAdaptedClient client =
                 new JsonAdaptedClient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, Client::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedClient Client = new JsonAdaptedClient(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, Client::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
-        JsonAdaptedClient Client =
+        JsonAdaptedClient client =
                 new JsonAdaptedClient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, Client::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedClient Client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, Client::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
-        JsonAdaptedClient Client =
+        JsonAdaptedClient client =
                 new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, Client::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedClient Client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, Client::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedClient Client =
+        JsonAdaptedClient client =
                 new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
-        assertThrows(IllegalValueException.class, Client::toModelType);
+        assertThrows(IllegalValueException.class, client::toModelType);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/ClientBuilder.java
+++ b/src/test/java/seedu/address/testutil/ClientBuilder.java
@@ -3,8 +3,11 @@ package seedu.address.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
-import seedu.address.model.client.*;
+import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Email;
+import seedu.address.model.client.Name;
+import seedu.address.model.client.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -36,7 +39,7 @@ public class ClientBuilder {
     }
 
     /**
-     * Initializes the ClientBuilder with the data of {@code ClientToCopy}.
+     * Initializes the ClientBuilder with the data of {@code clientToCopy}.
      */
     public ClientBuilder(Client clientToCopy) {
         name = clientToCopy.getName();

--- a/src/test/java/seedu/address/testutil/ClientUtil.java
+++ b/src/test/java/seedu/address/testutil/ClientUtil.java
@@ -19,14 +19,14 @@ import seedu.address.model.tag.Tag;
 public class ClientUtil {
 
     /**
-     * Returns an add command string for adding the {@code Client}.
+     * Returns an add command string for adding the {@code client}.
      */
     public static String getAddCommand(Client client) {
         return AddCommand.COMMAND_WORD + " " + getClientDetails(client);
     }
 
     /**
-     * Returns the part of command string for the given {@code Client}'s details.
+     * Returns the part of command string for the given {@code client}'s details.
      */
     public static String getClientDetails(Client client) {
         StringBuilder sb = new StringBuilder();

--- a/src/test/java/seedu/address/testutil/EditClientDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditClientDescriptorBuilder.java
@@ -6,9 +6,9 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditCommand.EditClientDescriptor;
 import seedu.address.model.client.Address;
+import seedu.address.model.client.Client;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
-import seedu.address.model.client.Client;
 import seedu.address.model.client.Phone;
 import seedu.address.model.tag.Tag;
 
@@ -28,7 +28,7 @@ public class EditClientDescriptorBuilder {
     }
 
     /**
-     * Returns an {@code EditClientDescriptor} with fields containing {@code Client}'s details
+     * Returns an {@code EditClientDescriptor} with fields containing {@code client}'s details
      */
     public EditClientDescriptorBuilder(Client client) {
         descriptor = new EditClientDescriptor();

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -33,21 +33,21 @@ public class TestUtil {
     }
 
     /**
-     * Returns the middle index of the Client in the {@code model}'s Client list.
+     * Returns the middle index of the client in the {@code model}'s client list.
      */
     public static Index getMidIndex(Model model) {
         return Index.fromOneBased(model.getFilteredClientList().size() / 2);
     }
 
     /**
-     * Returns the last index of the Client in the {@code model}'s Client list.
+     * Returns the last index of the client in the {@code model}'s client list.
      */
     public static Index getLastIndex(Model model) {
         return Index.fromOneBased(model.getFilteredClientList().size());
     }
 
     /**
-     * Returns the Client in the {@code model}'s Client list at {@code index}.
+     * Returns the client in the {@code model}'s client list at {@code index}.
      */
     public static Client getClient(Model model, Index index) {
         return model.getFilteredClientList().get(index.getZeroBased());

--- a/src/test/java/seedu/address/testutil/TypicalClients.java
+++ b/src/test/java/seedu/address/testutil/TypicalClients.java
@@ -60,7 +60,7 @@ public class TypicalClients {
     private TypicalClients() {} // prevents instantiation
 
     /**
-     * Returns an {@code AddressBook} with all the typical Clients.
+     * Returns an {@code AddressBook} with all the typical clients.
      */
     public static AddressBook getTypicalAddressBook() {
         AddressBook ab = new AddressBook();


### PR DESCRIPTION
There are minor naming issues for the previous PR for the mixed use of the term 'client' and 'Client,' which may cause regression.

This PR solves such naming issues by treating 'client' and 'Client' separately when renaming 'person' and 'Person.'